### PR TITLE
Add method "getDeviceResolution" to lstg.WindowHelper

### DIFF
--- a/frameworks/Classes/WindowHelper.cpp
+++ b/frameworks/Classes/WindowHelper.cpp
@@ -256,33 +256,35 @@ float WindowHelperDesktop::getDpiScale()
 	return (xscale + yscale) / 2;
 }
 
-std::vector<cocos2d::Vec2> lstg::WindowHelperDesktop::enumDeviceResolution()
+cocos2d::Vec2 WindowHelperDesktop::getDisplayResolution()
 {
-	DEVMODE devMode{};
+	return view->getMonitorSize();
+}
 
-	int modeNum = 0;
-	
+std::vector<cocos2d::Vec2> lstg::WindowHelperDesktop::enumDisplayResolution()
+{
 	std::vector<cocos2d::Vec2> res{};
 
-	while (EnumDisplaySettings(nullptr, modeNum, &devMode))
+	GLFWmonitor* monitor = glfwGetPrimaryMonitor();
+
+	int count;
+	const GLFWvidmode* modes = glfwGetVideoModes(monitor, &count);
+
+	for (int i = 0; i < count; i++)
 	{
-		// 检查对于宽高，是否已经存在，因为枚举显示设置时会将刷新率纳入考虑
-		bool exist = false;
-		for (auto& v : res)
+		const auto& mode = modes[i];
+		bool duplicate = false;
+		for (const auto& r : res)
 		{
-			if (v.x == devMode.dmPelsWidth && v.y == devMode.dmPelsHeight)
+			if (r.x == mode.width && r.y == mode.height)
 			{
-				exist = true;
+				duplicate = true;
 				break;
 			}
 		}
-		if (exist)
-		{
-			modeNum++;
+		if (duplicate)
 			continue;
-		}
-		res.push_back({ static_cast<float>(devMode.dmPelsWidth), static_cast<float>(devMode.dmPelsHeight) });
-		modeNum++;
+		res.push_back({ float(mode.width), float(mode.height) });
 	}
 
 	return res;
@@ -290,6 +292,7 @@ std::vector<cocos2d::Vec2> lstg::WindowHelperDesktop::enumDeviceResolution()
 
 void lstg::WindowHelperDesktop::setImeEnabled(bool enabled)
 {
+#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
 	HWND hwnd = Director::getInstance()->getOpenGLView()->getWin32Window();
 	HIMC hIMC = ImmGetContext(hwnd);
 	if (hIMC)
@@ -297,10 +300,28 @@ void lstg::WindowHelperDesktop::setImeEnabled(bool enabled)
 		ImmSetOpenStatus(hIMC, enabled);
 		ImmReleaseContext(hwnd, hIMC);
 	}
+#endif
+
+#if CC_TARGET_PLATFORM == CC_PLATFORM_MAC
+	// TODO
+#endif
+
+#if CC_TARGET_PLATFORM == CC_PLATFORM_LINUX
+	// TODO
+#endif
+
+#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
+	// TODO
+#endif
+
+#if CC_TARGET_PLATFORM == CC_PLATFORM_IOS
+	// TODO
+#endif
 }
 
 bool lstg::WindowHelperDesktop::isImeEnabled()
 {
+#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
 	HWND hwnd = Director::getInstance()->getOpenGLView()->getWin32Window();
 	HIMC hIMC = ImmGetContext(hwnd);
 	if (hIMC)
@@ -309,7 +330,25 @@ bool lstg::WindowHelperDesktop::isImeEnabled()
 		ImmReleaseContext(hwnd, hIMC);
 		return b;
 	}
+
 	return false;
+#endif
+
+#if CC_TARGET_PLATFORM == CC_PLATFORM_MAC
+	// TODO
+#endif
+
+#if CC_TARGET_PLATFORM == CC_PLATFORM_LINUX
+	// TODO
+#endif
+
+#if CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID
+	// TODO
+#endif
+
+#if CC_TARGET_PLATFORM == CC_PLATFORM_IOS
+	// TODO
+#endif
 }
 
 GLFWwindow* WindowHelperDesktop::getWindow()

--- a/frameworks/Classes/WindowHelper.cpp
+++ b/frameworks/Classes/WindowHelper.cpp
@@ -256,6 +256,14 @@ float WindowHelperDesktop::getDpiScale()
 	return (xscale + yscale) / 2;
 }
 
+cocos2d::Vec2 lstg::WindowHelperDesktop::getDeviceResolution()
+{
+	DEVMODE devMode{};
+	EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode);
+
+	return cocos2d::Vec2(devMode.dmPelsWidth,devMode.dmPelsHeight);
+}
+
 GLFWwindow* WindowHelperDesktop::getWindow()
 {
 	return view->getWindow();

--- a/frameworks/Classes/WindowHelper.cpp
+++ b/frameworks/Classes/WindowHelper.cpp
@@ -256,13 +256,11 @@ float WindowHelperDesktop::getDpiScale()
 	return (xscale + yscale) / 2;
 }
 
-std::vector<cocos2d::Vec2> lstg::WindowHelperDesktop::getDeviceResolution()
+std::vector<cocos2d::Vec2> lstg::WindowHelperDesktop::enumDeviceResolution()
 {
 	DEVMODE devMode{};
 
 	int modeNum = 0;
-
-	// 构建一个Lua表，将枚举出的值保存在此处
 	
 	std::vector<cocos2d::Vec2> res{};
 
@@ -290,26 +288,28 @@ std::vector<cocos2d::Vec2> lstg::WindowHelperDesktop::getDeviceResolution()
 	return res;
 }
 
-void lstg::WindowHelperDesktop::EnableIME()
+void lstg::WindowHelperDesktop::setImeEnabled(bool enabled)
 {
 	HWND hwnd = Director::getInstance()->getOpenGLView()->getWin32Window();
 	HIMC hIMC = ImmGetContext(hwnd);
 	if (hIMC)
 	{
-		ImmSetOpenStatus(hIMC, TRUE);
+		ImmSetOpenStatus(hIMC, enabled);
 		ImmReleaseContext(hwnd, hIMC);
 	}
 }
 
-void lstg::WindowHelperDesktop::DisableIME()
+bool lstg::WindowHelperDesktop::isImeEnabled()
 {
 	HWND hwnd = Director::getInstance()->getOpenGLView()->getWin32Window();
 	HIMC hIMC = ImmGetContext(hwnd);
 	if (hIMC)
 	{
-		ImmSetOpenStatus(hIMC, FALSE);
+		bool b = ImmGetOpenStatus(hIMC);
 		ImmReleaseContext(hwnd, hIMC);
+		return b;
 	}
+	return false;
 }
 
 GLFWwindow* WindowHelperDesktop::getWindow()

--- a/frameworks/Classes/WindowHelper.cpp
+++ b/frameworks/Classes/WindowHelper.cpp
@@ -264,6 +264,28 @@ cocos2d::Vec2 lstg::WindowHelperDesktop::getDeviceResolution()
 	return cocos2d::Vec2(devMode.dmPelsWidth,devMode.dmPelsHeight);
 }
 
+void lstg::WindowHelperDesktop::EnableIME()
+{
+	HWND hwnd = Director::getInstance()->getOpenGLView()->getWin32Window();
+	HIMC hIMC = ImmGetContext(hwnd);
+	if (hIMC)
+	{
+		ImmSetOpenStatus(hIMC, TRUE);
+		ImmReleaseContext(hwnd, hIMC);
+	}
+}
+
+void lstg::WindowHelperDesktop::DisableIME()
+{
+	HWND hwnd = Director::getInstance()->getOpenGLView()->getWin32Window();
+	HIMC hIMC = ImmGetContext(hwnd);
+	if (hIMC)
+	{
+		ImmSetOpenStatus(hIMC, FALSE);
+		ImmReleaseContext(hwnd, hIMC);
+	}
+}
+
 GLFWwindow* WindowHelperDesktop::getWindow()
 {
 	return view->getWindow();

--- a/frameworks/Classes/WindowHelper.cpp
+++ b/frameworks/Classes/WindowHelper.cpp
@@ -256,12 +256,38 @@ float WindowHelperDesktop::getDpiScale()
 	return (xscale + yscale) / 2;
 }
 
-cocos2d::Vec2 lstg::WindowHelperDesktop::getDeviceResolution()
+std::vector<cocos2d::Vec2> lstg::WindowHelperDesktop::getDeviceResolution()
 {
 	DEVMODE devMode{};
-	EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode);
 
-	return cocos2d::Vec2(devMode.dmPelsWidth,devMode.dmPelsHeight);
+	int modeNum = 0;
+
+	// 构建一个Lua表，将枚举出的值保存在此处
+	
+	std::vector<cocos2d::Vec2> res{};
+
+	while (EnumDisplaySettings(nullptr, modeNum, &devMode))
+	{
+		// 检查对于宽高，是否已经存在，因为枚举显示设置时会将刷新率纳入考虑
+		bool exist = false;
+		for (auto& v : res)
+		{
+			if (v.x == devMode.dmPelsWidth && v.y == devMode.dmPelsHeight)
+			{
+				exist = true;
+				break;
+			}
+		}
+		if (exist)
+		{
+			modeNum++;
+			continue;
+		}
+		res.push_back({ static_cast<float>(devMode.dmPelsWidth), static_cast<float>(devMode.dmPelsHeight) });
+		modeNum++;
+	}
+
+	return res;
 }
 
 void lstg::WindowHelperDesktop::EnableIME()

--- a/frameworks/Classes/WindowHelper.h
+++ b/frameworks/Classes/WindowHelper.h
@@ -66,7 +66,11 @@ namespace lstg
 
 		virtual float getDpiScale() { return 1.0f; }
 
-		virtual std::vector<cocos2d::Vec2> enumDeviceResolution() {
+		virtual cocos2d::Vec2 getDisplayResolution() {
+			return cocos2d::Vec2{};
+		}
+
+		virtual std::vector<cocos2d::Vec2> enumDisplayResolution() {
 			return std::vector<cocos2d::Vec2>{};
 		}
 
@@ -140,7 +144,8 @@ namespace lstg
 
 		float getDpiScale() override;
 
-		std::vector<cocos2d::Vec2> enumDeviceResolution() override;
+		cocos2d::Vec2 getDisplayResolution() override;
+		std::vector<cocos2d::Vec2> enumDisplayResolution() override;
 
 		void setImeEnabled(bool enabled) override;
 		bool isImeEnabled() override;

--- a/frameworks/Classes/WindowHelper.h
+++ b/frameworks/Classes/WindowHelper.h
@@ -65,6 +65,8 @@ namespace lstg
 		virtual void setStandardCursor(CursorType type) {}
 
 		virtual float getDpiScale() { return 1.0f; }
+
+		virtual cocos2d::Vec2 getDeviceResolution() { return cocos2d::Vec2(); }
 	protected:
 		std::string title;
 		bool visible = true;
@@ -132,6 +134,8 @@ namespace lstg
 		void setStandardCursor(CursorType type) override;
 
 		float getDpiScale() override;
+
+		cocos2d::Vec2 getDeviceResolution() override;
 	protected:
 		// it's better to get window dynamicly
 		GLFWwindow* getWindow();

--- a/frameworks/Classes/WindowHelper.h
+++ b/frameworks/Classes/WindowHelper.h
@@ -67,6 +67,9 @@ namespace lstg
 		virtual float getDpiScale() { return 1.0f; }
 
 		virtual cocos2d::Vec2 getDeviceResolution() { return cocos2d::Vec2(); }
+
+		virtual void EnableIME() {};
+		virtual void DisableIME() {};
 	protected:
 		std::string title;
 		bool visible = true;
@@ -136,6 +139,9 @@ namespace lstg
 		float getDpiScale() override;
 
 		cocos2d::Vec2 getDeviceResolution() override;
+
+		void EnableIME() override;
+		void DisableIME() override;
 	protected:
 		// it's better to get window dynamicly
 		GLFWwindow* getWindow();

--- a/frameworks/Classes/WindowHelper.h
+++ b/frameworks/Classes/WindowHelper.h
@@ -66,7 +66,9 @@ namespace lstg
 
 		virtual float getDpiScale() { return 1.0f; }
 
-		virtual cocos2d::Vec2 getDeviceResolution() { return cocos2d::Vec2(); }
+		virtual std::vector<cocos2d::Vec2> getDeviceResolution() {
+			return std::vector<cocos2d::Vec2>{};
+		}
 
 		virtual void EnableIME() {};
 		virtual void DisableIME() {};
@@ -138,7 +140,7 @@ namespace lstg
 
 		float getDpiScale() override;
 
-		cocos2d::Vec2 getDeviceResolution() override;
+		std::vector<cocos2d::Vec2> getDeviceResolution() override;
 
 		void EnableIME() override;
 		void DisableIME() override;

--- a/frameworks/Classes/WindowHelper.h
+++ b/frameworks/Classes/WindowHelper.h
@@ -66,12 +66,12 @@ namespace lstg
 
 		virtual float getDpiScale() { return 1.0f; }
 
-		virtual std::vector<cocos2d::Vec2> getDeviceResolution() {
+		virtual std::vector<cocos2d::Vec2> enumDeviceResolution() {
 			return std::vector<cocos2d::Vec2>{};
 		}
 
-		virtual void EnableIME() {};
-		virtual void DisableIME() {};
+		virtual void setImeEnabled(bool enable) {};
+		virtual bool isImeEnabled() { return false; };
 	protected:
 		std::string title;
 		bool visible = true;
@@ -140,10 +140,10 @@ namespace lstg
 
 		float getDpiScale() override;
 
-		std::vector<cocos2d::Vec2> getDeviceResolution() override;
+		std::vector<cocos2d::Vec2> enumDeviceResolution() override;
 
-		void EnableIME() override;
-		void DisableIME() override;
+		void setImeEnabled(bool enabled) override;
+		bool isImeEnabled() override;
 	protected:
 		// it's better to get window dynamicly
 		GLFWwindow* getWindow();

--- a/frameworks/LuaBindings/lua_WindowHelper_auto.cpp
+++ b/frameworks/LuaBindings/lua_WindowHelper_auto.cpp
@@ -44,6 +44,18 @@ int lua_lstg_WindowHelper_getDeviceResolution(lua_State* lua_S)
 	LUA_TRY_INVOKE_R(0, &lstg::WindowHelper::getDeviceResolution);
 	LUA_INVOKE_FOOTER("0");
 }
+int lua_lstg_WindowHelper_EnableIME(lua_State* lua_S)
+{
+	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:EnableIME");
+	LUA_TRY_INVOKE(0, &lstg::WindowHelper::EnableIME);
+	LUA_INVOKE_FOOTER("0");
+}
+int lua_lstg_WindowHelper_DisableIME(lua_State* lua_S)
+{
+	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:DisableIME");
+	LUA_TRY_INVOKE(0, &lstg::WindowHelper::DisableIME);
+	LUA_INVOKE_FOOTER("0");
+}
 int lua_lstg_WindowHelper_getPosition(lua_State* lua_S)
 {
 	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:getPosition");

--- a/frameworks/LuaBindings/lua_WindowHelper_auto.cpp
+++ b/frameworks/LuaBindings/lua_WindowHelper_auto.cpp
@@ -38,6 +38,12 @@ int lua_lstg_WindowHelper_getDpiScale(lua_State* lua_S)
 	LUA_TRY_INVOKE_R(0, &lstg::WindowHelper::getDpiScale);
 	LUA_INVOKE_FOOTER("0");
 }
+int lua_lstg_WindowHelper_getDeviceResolution(lua_State* lua_S)
+{
+	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:getDeviceResolution");
+	LUA_TRY_INVOKE_R(0, &lstg::WindowHelper::getDeviceResolution);
+	LUA_INVOKE_FOOTER("0");
+}
 int lua_lstg_WindowHelper_getPosition(lua_State* lua_S)
 {
 	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:getPosition");
@@ -184,6 +190,7 @@ int luaReg_WindowHelper_lstgWindowHelper(lua_State* lua_S)
 		nullptr, nullptr);
 	LUA_METHOD("getClipboardString", lua_lstg_WindowHelper_getClipboardString);
 	LUA_METHOD("getDpiScale", lua_lstg_WindowHelper_getDpiScale);
+	LUA_METHOD("getDeviceResolution", lua_lstg_WindowHelper_getDeviceResolution);
 	LUA_METHOD("getPosition", lua_lstg_WindowHelper_getPosition);
 	LUA_METHOD("getSize", lua_lstg_WindowHelper_getSize);
 	LUA_METHOD("getTitle", lua_lstg_WindowHelper_getTitle);

--- a/frameworks/LuaBindings/lua_WindowHelper_auto.cpp
+++ b/frameworks/LuaBindings/lua_WindowHelper_auto.cpp
@@ -38,22 +38,22 @@ int lua_lstg_WindowHelper_getDpiScale(lua_State* lua_S)
 	LUA_TRY_INVOKE_R(0, &lstg::WindowHelper::getDpiScale);
 	LUA_INVOKE_FOOTER("0");
 }
-int lua_lstg_WindowHelper_getDeviceResolution(lua_State* lua_S)
+int lua_lstg_WindowHelper_enumDeviceResolution(lua_State* lua_S)
 {
-	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:getDeviceResolution");
-	LUA_TRY_INVOKE_R(0, &lstg::WindowHelper::getDeviceResolution);
+	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:enumDeviceResolution");
+	LUA_TRY_INVOKE_R(0, &lstg::WindowHelper::enumDeviceResolution);
 	LUA_INVOKE_FOOTER("0");
 }
-int lua_lstg_WindowHelper_EnableIME(lua_State* lua_S)
+int lua_lstg_WindowHelper_setImeEnabled(lua_State* lua_S)
 {
-	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:EnableIME");
-	LUA_TRY_INVOKE(0, &lstg::WindowHelper::EnableIME);
+	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:setImeEnabled");
+	LUA_TRY_INVOKE(0, &lstg::WindowHelper::setImeEnabled);
 	LUA_INVOKE_FOOTER("0");
 }
-int lua_lstg_WindowHelper_DisableIME(lua_State* lua_S)
+int lua_lstg_WindowHelper_isImeEnabled(lua_State* lua_S)
 {
-	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:DisableIME");
-	LUA_TRY_INVOKE(0, &lstg::WindowHelper::DisableIME);
+	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:isImeEnabled");
+	LUA_TRY_INVOKE(0, &lstg::WindowHelper::isImeEnabled);
 	LUA_INVOKE_FOOTER("0");
 }
 int lua_lstg_WindowHelper_getPosition(lua_State* lua_S)
@@ -202,7 +202,9 @@ int luaReg_WindowHelper_lstgWindowHelper(lua_State* lua_S)
 		nullptr, nullptr);
 	LUA_METHOD("getClipboardString", lua_lstg_WindowHelper_getClipboardString);
 	LUA_METHOD("getDpiScale", lua_lstg_WindowHelper_getDpiScale);
-	LUA_METHOD("getDeviceResolution", lua_lstg_WindowHelper_getDeviceResolution);
+	LUA_METHOD("enumDeviceResolution", lua_lstg_WindowHelper_enumDeviceResolution);
+	LUA_METHOD("setImeEnabled", lua_lstg_WindowHelper_setImeEnabled);
+	LUA_METHOD("isImeEnabled", lua_lstg_WindowHelper_isImeEnabled);
 	LUA_METHOD("getPosition", lua_lstg_WindowHelper_getPosition);
 	LUA_METHOD("getSize", lua_lstg_WindowHelper_getSize);
 	LUA_METHOD("getTitle", lua_lstg_WindowHelper_getTitle);

--- a/frameworks/LuaBindings/lua_WindowHelper_auto.cpp
+++ b/frameworks/LuaBindings/lua_WindowHelper_auto.cpp
@@ -38,22 +38,28 @@ int lua_lstg_WindowHelper_getDpiScale(lua_State* lua_S)
 	LUA_TRY_INVOKE_R(0, &lstg::WindowHelper::getDpiScale);
 	LUA_INVOKE_FOOTER("0");
 }
+int lua_lstg_WindowHelper_getCurrentDeviceResolution(lua_State* lua_S)
+{
+	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:getDisplayResolution");
+	LUA_TRY_INVOKE_R(0, &lstg::WindowHelper::getDisplayResolution);
+	LUA_INVOKE_FOOTER("0");
+}
 int lua_lstg_WindowHelper_enumDeviceResolution(lua_State* lua_S)
 {
-	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:enumDeviceResolution");
-	LUA_TRY_INVOKE_R(0, &lstg::WindowHelper::enumDeviceResolution);
+	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:enumDisplayResolution");
+	LUA_TRY_INVOKE_R(0, &lstg::WindowHelper::enumDisplayResolution);
 	LUA_INVOKE_FOOTER("0");
 }
 int lua_lstg_WindowHelper_setImeEnabled(lua_State* lua_S)
 {
 	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:setImeEnabled");
-	LUA_TRY_INVOKE(0, &lstg::WindowHelper::setImeEnabled);
+	LUA_TRY_INVOKE(1, &lstg::WindowHelper::setImeEnabled);
 	LUA_INVOKE_FOOTER("0");
 }
 int lua_lstg_WindowHelper_isImeEnabled(lua_State* lua_S)
 {
 	LUA_INVOKE_HEADER("lstg.WindowHelper", "lstg.WindowHelper:isImeEnabled");
-	LUA_TRY_INVOKE(0, &lstg::WindowHelper::isImeEnabled);
+	LUA_TRY_INVOKE_R(0, &lstg::WindowHelper::isImeEnabled);
 	LUA_INVOKE_FOOTER("0");
 }
 int lua_lstg_WindowHelper_getPosition(lua_State* lua_S)
@@ -202,7 +208,8 @@ int luaReg_WindowHelper_lstgWindowHelper(lua_State* lua_S)
 		nullptr, nullptr);
 	LUA_METHOD("getClipboardString", lua_lstg_WindowHelper_getClipboardString);
 	LUA_METHOD("getDpiScale", lua_lstg_WindowHelper_getDpiScale);
-	LUA_METHOD("enumDeviceResolution", lua_lstg_WindowHelper_enumDeviceResolution);
+	LUA_METHOD("getDisplayResolution", lua_lstg_WindowHelper_getCurrentDeviceResolution);
+	LUA_METHOD("enumDisplayResolution", lua_lstg_WindowHelper_enumDeviceResolution);
 	LUA_METHOD("setImeEnabled", lua_lstg_WindowHelper_setImeEnabled);
 	LUA_METHOD("isImeEnabled", lua_lstg_WindowHelper_isImeEnabled);
 	LUA_METHOD("getPosition", lua_lstg_WindowHelper_getPosition);


### PR DESCRIPTION
This API is for getting hardware output resolution in runtime ,independent from Graphic API,instead of old API for OpenGL backend.